### PR TITLE
Vivint changed id token, o= to a=

### DIFF
--- a/vivint.py
+++ b/vivint.py
@@ -653,7 +653,7 @@ class VivintCloudSession(object):
                 "Attempt to fetch the app.js file resulted in non-200 response code",
                 resp.__dict__)
 
-        match = re.search(r'r="id_token",o="([0-9a-f]*)"', resp.data.decode())
+        match = re.search(r'r="id_token",a="([0-9a-f]*)"', resp.data.decode())
         if match is None:
             raise Exception(
                 "Unable to find client id within the app.js package.")


### PR DESCRIPTION
HotFix - I am not sure if yours still works with o= in the token ID but mine is no longer working like that. I had to change it to a=. 